### PR TITLE
Refactor redirect synchronization scripts and update deployment workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -24,10 +24,11 @@ concurrency:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,7 +47,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
-          path: 'docs/'
+          path: 'public/'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -173,4 +173,8 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-docs/
+#
+public/
+
+#
+make-psdocs.ps1

--- a/docs/Sync-Redirects.md
+++ b/docs/Sync-Redirects.md
@@ -1,0 +1,163 @@
+---
+external help file: Sync-Redirects-help.xml
+ModuleVersion: 1.0.1
+online version: https://github.com/kjanat/url-shortener/blob/master/docs/Sync-Redirects.md
+schema: 2.0.0
+---
+
+# Sync-Redirects
+
+## SYNOPSIS
+
+Synchronizes redirects between JSON and YAML files.
+
+## SYNTAX
+
+```pwsh
+Sync-Redirects `
+    [[-GitRoot] <String>] `
+    [[-jsonFile] <String>] `
+    [[-yamlFile] <String>] `
+    [-ProgressAction <ActionPreference>] `
+    [-WhatIf] `
+    [-Confirm] `
+    [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This function compares the contents of a JSON file and a YAML file, determines which file is newer, and updates the other file with any missing entries.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```pwsh
+Sync-Redirects.ps1
+```
+
+This example synchronizes the redirects between the default JSON and YAML files in the script's directory.
+
+### EXAMPLE 2
+
+```pwsh
+Sync-Redirects.ps1 `
+    -jsonFile "C:\path\to\redirects.json" `
+    -yamlFile "C:\path\to\redirects.yml"
+```
+
+Synchronizes the redirects between the specified JSON and YAML files.
+
+### EXAMPLE 3
+
+```pwsh
+Sync-Redirects.ps1 `
+    -GitRoot "C:\path\to\git\repository" `
+    -jsonFile "C:\path\to\redirects.json" `
+    -yamlFile "C:\path\to\redirects.yml"
+```
+
+Synchronizes the redirects between the specified JSON and YAML files in the specified Git repository.
+
+## PARAMETERS
+
+### -GitRoot
+
+The root directory of the Git repository containing the JSON and YAML files.
+
+```yaml
+Type: System.Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: "($PSScriptRoot -match '^\s*$' ? (Get-Item 'C:\Users\kjana\Projects\url-shortener\') : (Get-Item $PSScriptRoot).Parent)"
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -jsonFile
+
+The path to the JSON file containing redirects.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: "(Join-Path -Path $GitRoot -ChildPath 'redirects.json')"
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -yamlFile
+
+The path to the YAML file containing redirects.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: "(Join-Path -Path $GitRoot -ChildPath 'redirects.yml')"
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+
+The action to take when progress information is written. The default value is `Continue`, which displays the progress bar. Other options include `SilentlyContinue`, `Inquire`, `Ignore`, and `Stop`.
+
+```yaml
+Type: System.Management.Automation.ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`.  
+For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## RELATED LINKS
+
+[Sync-Redirects Documentation](https://github.com/kjanat/url-shortener/blob/master/docs/Sync-Redirects.md)

--- a/generate_redirects.py
+++ b/generate_redirects.py
@@ -19,39 +19,108 @@ elif os.path.exists(yaml_file):
 else:
     raise FileNotFoundError("No redirects.json or redirects.yml file found.")
 
-# Ensure docs directory is clean
-if os.path.exists("docs"):
-    for file in os.listdir("docs"):
-        os.remove(os.path.join("docs", file))
+# Ensure public directory is clean
+if os.path.exists("public"):
+    for file in os.listdir("public"):
+        os.remove(os.path.join("public", file))
 else:
-    os.makedirs("docs")
+    os.makedirs("public")
 
+# Update the style variable
+style = """
+body {
+  font-family: 'Roboto', sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f4f4f9;
+  color: #333;
+}
+h1, h2 {
+  color: #444;
+}
+a {
+  color: #007BFF;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+li {
+  margin: 0.5em 0;
+}
+.container {
+  max-width: 800px;
+  margin: 2em auto;
+  padding: 1em;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+"""
+
+# Update the template to use the escaped style
 template = """<!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv=\"refresh\" content=\"0; URL='{}'\" />
-    <title>Redirecting...</title>
-  </head>
-  <body>
-    <p>Redirecting to {}...</p>
-  </body>
+    <head>
+        <meta http-equiv="refresh" content="0; URL='{}'" />
+        <title>Redirecting...</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link href='https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap' rel='stylesheet'>
+        <style>{}</style>
+    </head>
+    <body>
+        <div class='container'>
+            <p>Redirecting to {}...</p>
+        </div>
+    </body>
 </html>
 """
 
 # Generate individual redirect pages
 for slug, data in redirects.items():
     url = data["url"] if isinstance(data, dict) else data
-    with open(f"docs/{slug}.html", "w") as f:
-        f.write(template.format(url, url))
+    with open(f"public/{slug}.html", "w") as f:
+        f.write(template.format(url, style, url))
 
-# Generate index.html with an overview of all available redirects
-with open("docs/index.html", "w") as index:
-    index.write("<!DOCTYPE html>\n<html>\n  <head><title>Redirect links</title></head>\n  <body>\n    <h1>Short Links</h1>\n    <ul>\n")
-    for slug, data in sorted(redirects.items()):  # Sort by slug
-        url = data["url"] if isinstance(data, dict) else data
-        description = data.get("description", "") if isinstance(data, dict) else ""
-        if description:
-            index.write(f'      <li><a href="{slug}.html">{slug}</a>: {description}</li>\n')
-        else:
-            index.write(f'      <li><a href="{slug}.html">{slug}</a></li>\n')
-    index.write("    </ul>\n  </body>\n</html>")
+# Generate the index.html file with the updated style
+with open("public/index.html", "w") as index:
+    index.write("""<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirect links</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href='https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap' rel='stylesheet'>
+    <style>{}</style>
+  </head>
+  <body>
+    <div class='container'>
+      <h1>KJANAT URL Shortener</h1>
+""".format(style))
+
+    # Group redirects by category
+    categorized_redirects = {}
+    for slug, data in redirects.items():
+        category = data.get("category", "") if isinstance(data, dict) else "Uncategorized"
+        if category not in categorized_redirects:
+            categorized_redirects[category] = []
+        categorized_redirects[category].append((slug, data))
+
+    # Write categories and their links
+    for category, items in sorted(categorized_redirects.items()):
+        index.write(f"<h2>{category}</h2><ul>")
+        for slug, data in sorted(items):
+            url = data["url"] if isinstance(data, dict) else data
+            description = data.get("description", "") if isinstance(data, dict) else ""
+            if description:
+                index.write(f'<li><a href="{slug}.html">{slug}</a>: {description}</li>')
+            else:
+                index.write(f'<li><a href="{slug}.html">{slug}</a></li>')
+        index.write("</ul>")
+
+    index.write("</div></body></html>")

--- a/launch.json
+++ b/launch.json
@@ -1,0 +1,22 @@
+{
+  "configurations": [
+    {
+      "type": "debugpy",
+      "request": "launch",
+      "name": "Launch generate_redirects.py",
+      "program": "${workspaceFolder}/${input:programPath}",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ],
+  "inputs": [
+    {
+      "type": "pickString",
+      "id": "programPath",
+      "description": "Select the Python file to debug",
+      "options": [
+        "generate_redirects.py"
+      ]
+    }
+  ]
+}

--- a/redirects.json
+++ b/redirects.json
@@ -1,18 +1,34 @@
 {
-  "docs": {
-    "url": "https://docs.kajkowalski.nl",
-    "description": "Documentation for Kaj Kowalski"
-  },
-  "pdf": {
-    "url": "https://pdf.kajkowalski.nl",
-    "description": "PDF resources"
-  },
-  "pdf-js": {
-    "url": "https://pdf-js.kajkowalski.nl",
-    "description": "PDF.js resources"
-  },
-  "books": {
-    "url": "https://books.kjanat.com",
-    "description": "Books by Kaj Kowalski"
-  }
+	"pdf": {
+		"url": "https://pdf.kajkowalski.nl",
+		"description": "PDF OCR (Python backend)",
+		"category": "demo sites"
+	},
+	"pdf-js": {
+		"url": "https://pdf-js.kajkowalski.nl",
+		"description": "PDF OCR (JS Backend)",
+		"category": "demo sites"
+	},
+	"docs": {
+		"url": "https://docs.kajkowalski.nl",
+		"description": "Paperless-ngx server",
+		"category": "media"
+	},
+	"cal": {
+		"url": "https://www.google.com/calendar/hosted/kajkowalski.nl",
+		"description": "Google Calendar"
+	},
+	"books": {
+		"url": "https://books.kjanat.com",
+		"description": "Calibre-Web server",
+		"category": "media"
+	},
+	"new-entry": {
+		"url": "https://new-entry.example.com",
+		"description": "New entry description",
+		"category": "new category"
+	},
+	"google.com": {
+		"url": "https://www.google.com"
+	}
 }

--- a/redirects.yml
+++ b/redirects.yml
@@ -1,15 +1,25 @@
 books:
-    description: "Calibre-Web server"
-    url: "https://books.kjanat.com"
-docs:
-    description: "Paperless-ngx server"
-    url: "https://docs.kajkowalski.nl"
-pdf:
-    description: "PDF OCR (Python backend)"
-    url: "https://pdf.kajkowalski.nl"
-pdf-js:
-    description: "PDF OCR (JS Backend)"
-    url: "https://pdf-js.kajkowalski.nl"
+    category: media
+    description: Calibre-Web server
+    url: https://books.kjanat.com
 cal:
-    description: "Google Calendar"
-    url: "https://www.google.com/calendar/hosted/kajkowalski.nl"
+    description: Google Calendar
+    url: https://www.google.com/calendar/hosted/kajkowalski.nl
+docs:
+    category: media
+    description: Paperless-ngx server
+    url: https://docs.kajkowalski.nl
+pdf:
+    category: demo sites
+    description: PDF OCR (Python backend)
+    url: https://pdf.kajkowalski.nl
+pdf-js:
+    category: demo sites
+    description: PDF OCR (JS Backend)
+    url: https://pdf-js.kajkowalski.nl
+new-entry:
+    category: new category
+    description: New entry description
+    url: https://new-entry.example.com
+google.com:
+    url: https://www.google.com

--- a/scripts/.externalhelpfiles/en-US/Sync-Redirects-help.xml
+++ b/scripts/.externalhelpfiles/en-US/Sync-Redirects-help.xml
@@ -1,0 +1,204 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Sync-Redirects</command:name>
+      <command:verb>Sync</command:verb>
+      <command:noun>Redirects</command:noun>
+      <maml:description>
+        <maml:para>Synchronizes redirects between JSON and YAML files.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>This function compares the contents of a JSON file and a YAML file, determines which file is newer, and updates the other file with any missing entries.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Sync-Redirects</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
+          <maml:name>GitRoot</maml:name>
+          <maml:description>
+            <maml:para>The root directory of the Git repository containing the JSON and YAML files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">System.Object</command:parameterValue>
+          <dev:type>
+            <maml:name>System.Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>($PSScriptRoot -match '^\s*$' ? (Get-Item 'C:\Users\kjana\Projects\url-shortener\') : (Get-Item $PSScriptRoot).Parent)</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="2" aliases="none">
+          <maml:name>jsonFile</maml:name>
+          <maml:description>
+            <maml:para>The path to the JSON file containing redirects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">System.String</command:parameterValue>
+          <dev:type>
+            <maml:name>System.String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>(Join-Path -Path $GitRoot -ChildPath 'redirects.json')</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="3" aliases="none">
+          <maml:name>yamlFile</maml:name>
+          <maml:description>
+            <maml:para>The path to the YAML file containing redirects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">System.String</command:parameterValue>
+          <dev:type>
+            <maml:name>System.String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>(Join-Path -Path $GitRoot -ChildPath 'redirects.yml')</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>The action to take when progress information is written. The default value is `Continue`, which displays the progress bar. Other options include `SilentlyContinue`, `Inquire`, `Ignore`, and `Stop`.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">System.Management.Automation.ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>System.Management.Automation.ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">System.Management.Automation.SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
+        <maml:name>GitRoot</maml:name>
+        <maml:description>
+          <maml:para>The root directory of the Git repository containing the JSON and YAML files.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">System.Object</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>($PSScriptRoot -match '^\s*$' ? (Get-Item 'C:\Users\kjana\Projects\url-shortener\') : (Get-Item $PSScriptRoot).Parent)</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">System.Management.Automation.SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="2" aliases="none">
+        <maml:name>jsonFile</maml:name>
+        <maml:description>
+          <maml:para>The path to the JSON file containing redirects.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">System.String</command:parameterValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>(Join-Path -Path $GitRoot -ChildPath 'redirects.json')</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="3" aliases="none">
+        <maml:name>yamlFile</maml:name>
+        <maml:description>
+          <maml:para>The path to the YAML file containing redirects.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">System.String</command:parameterValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>(Join-Path -Path $GitRoot -ChildPath 'redirects.yml')</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>The action to take when progress information is written. The default value is `Continue`, which displays the progress bar. Other options include `SilentlyContinue`, `Inquire`, `Ignore`, and `Stop`.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">System.Management.Automation.ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Management.Automation.ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert />
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Sync-Redirects.ps1</dev:code>
+        <dev:remarks>
+          <maml:para>This example synchronizes the redirects between the default JSON and YAML files in the script's directory.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Sync-Redirects.ps1 `
+    -jsonFile "C:\path\to\redirects.json" `
+    -yamlFile "C:\path\to\redirects.yml"</dev:code>
+        <dev:remarks>
+          <maml:para>Synchronizes the redirects between the specified JSON and YAML files.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Sync-Redirects.ps1 `
+    -GitRoot "C:\path\to\git\repository" `
+    -jsonFile "C:\path\to\redirects.json" `
+    -yamlFile "C:\path\to\redirects.yml"</dev:code>
+        <dev:remarks>
+          <maml:para>Synchronizes the redirects between the specified JSON and YAML files in the specified Git repository.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Sync-Redirects Documentation</maml:linkText>
+        <maml:uri>https://github.com/kjanat/url-shortener/blob/master/docs/Sync-Redirects.md</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+</helpItems>

--- a/scripts/Sync-Redirects.ps1
+++ b/scripts/Sync-Redirects.ps1
@@ -1,0 +1,175 @@
+<#
+.SYNOPSIS
+Synchronizes redirects between JSON and YAML files.
+
+.DESCRIPTION
+This function compares the contents of a JSON file and a YAML file, determines which file is newer, and updates the other file with any missing entries.
+
+.PARAMETER GitRoot
+The root directory of the Git repository containing the JSON and YAML files.
+
+.PARAMETER jsonFile
+The path to the JSON file containing redirects.
+
+.PARAMETER yamlFile
+The path to the YAML file containing redirects.
+
+.EXAMPLE
+Sync-Redirects.ps1
+
+This example synchronizes the redirects between the default JSON and YAML files in the script's directory.
+
+.EXAMPLE
+Sync-Redirects.ps1 `
+    -jsonFile "C:\path\to\redirects.json" `
+    -yamlFile "C:\path\to\redirects.yml"
+
+Synchronizes the redirects between the specified JSON and YAML files.
+
+.EXAMPLE
+Sync-Redirects.ps1 `
+    -GitRoot "C:\path\to\git\repository" `
+    -jsonFile "C:\path\to\redirects.json" `
+    -yamlFile "C:\path\to\redirects.yml"
+
+Synchronizes the redirects between the specified JSON and YAML files in the specified Git repository.
+
+.LINK
+https://github.com/kjanat/url-shortener/blob/master/docs/Sync-Redirects.md
+
+.EXTERNALHELP .externalhelpfiles/en-US/Sync-Redirects-help.xml
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param (
+    [Parameter(Mandatory = $false, ValueFromPipeline, ValueFromPipelineByPropertyName, HelpMessage = 'The root directory of the Git repository. Defaults to the parent directory of the script.')]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$GitRoot = ($PSScriptRoot -match '^\s*$' ? (Get-Item 'C:\Users\kjana\Projects\url-shortener\') : (Get-Item $PSScriptRoot).Parent),
+    
+    [Parameter(Mandatory = $false, ValueFromPipeline, ValueFromPipelineByPropertyName, HelpMessage = 'The path to the JSON file containing redirects.')]
+    [ValidateScript({ Test-Path $_ -PathType Leaf })]
+    [string]$jsonFile = (Join-Path -Path $GitRoot -ChildPath 'redirects.json'),
+    
+    [Parameter(Mandatory = $false, ValueFromPipeline, ValueFromPipelineByPropertyName, HelpMessage = 'The path to the YAML file containing redirects.')]
+    [ValidateScript({ Test-Path $_ -PathType Leaf })]
+    [string]$yamlFile = (Join-Path -Path $GitRoot -ChildPath 'redirects.yml')
+)
+
+Write-Verbose 'Starting redirects synchronization process'
+
+# Write debug the variables from parameters
+$PSBoundParameters.GetEnumerator() | ForEach-Object {
+    Write-Debug "$($_.Key):`t`t$($_.Value)"
+}
+Write-Debug "GitRoot: `t$GitRoot"
+Write-Debug "jsonFile:`t$jsonFile"
+Write-Debug "yamlFile:`t$yamlFile"
+
+# Load required module
+Write-Verbose 'Checking for required module: powershell-yaml'
+if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
+    Write-Error "The 'powershell-yaml' module is required. Please install it using 'Install-Module powershell-yaml'."
+    exit 1
+}
+Write-Debug "Module 'powershell-yaml' is available"
+
+# Get file modification times
+Write-Verbose 'Getting file modification times'
+$jsonLastModified = (Get-Item $jsonFile).LastWriteTime
+$yamlLastModified = (Get-Item $yamlFile).LastWriteTime
+Write-Debug "JSON last modified: $(Get-Date $jsonLastModified -UFormat '%c')"
+Write-Debug "YAML last modified: $(Get-Date $yamlLastModified -UFormat '%c')"
+
+# Load file contents
+Write-Verbose 'Loading file contents'
+$jsonData = Get-Content $jsonFile | ConvertFrom-Json -AsHashtable
+$yamlData = Get-Content $yamlFile | ConvertFrom-Yaml
+Write-Debug "JSON entries count: $($jsonData.Count)"
+Write-Debug "YAML entries count: $($yamlData.Count)"
+
+# Determine the newer file
+if ($jsonLastModified -gt $yamlLastModified) {
+    Write-Verbose 'JSON file is newer than YAML file'
+    $hasChanges = $false
+    if ($yamlData.Count -lt $jsonData.Count) {
+        Write-Information 'JSON file has more entries than YAML file' -InformationAction Continue
+        $hasChanges = $true
+    } elseif ($yamlData.Count -gt $jsonData.Count) {
+        Write-Information 'YAML file has more entries than JSON file' -InformationAction Continue
+        $hasChanges = $true
+    } else {
+        Write-Information 'JSON file has the same number of entries as YAML file' -InformationAction Continue
+        foreach ($key in $yamlData.Keys) {
+            if (-not $jsonData.ContainsKey($key)) {
+                Write-Debug "Found key in YAML missing from JSON: $key"
+                $jsonData[$key] = $yamlData[$key]
+                $hasChanges = $true
+            }
+        }
+    }
+
+    if ($hasChanges) {
+        Write-Information 'Found entries in YAML that need to be added to JSON' -InformationAction Continue
+        if ($PSCmdlet.ShouldProcess($jsonFile, 'Update JSON file with missing entries from YAML')) {
+            Write-Verbose 'Updating JSON file with missing entries from YAML'
+            $jsonData | 
+                ConvertTo-Json -Depth 3 | 
+                Set-Content $jsonFile -Force
+        }
+        if ($PSCmdlet.ShouldProcess($yamlFile, 'Update YAML file from JSON data')) {
+            Write-Verbose 'Updating YAML file from JSON data for consistency'
+            $jsonData | ConvertTo-Yaml `
+                -OutFile $yamlFile `
+                -Force
+        }
+        if (-not $WhatIfPreference) {
+            Write-Information 'Synchronized YAML to JSON.' -InformationAction Continue
+        }
+    } else {
+        Write-Information 'No changes needed for synchronization.' -InformationAction Continue
+    }
+} elseif ($yamlLastModified -gt $jsonLastModified) {
+    Write-Verbose 'YAML file is newer than JSON file'
+    $hasChanges = $false
+    if ($jsonData.Count -lt $yamlData.Count) {
+        Write-Information 'YAML file has more entries than JSON file' -InformationAction Continue
+        $hasChanges = $true
+    } elseif ($jsonData.Count -gt $yamlData.Count) {
+        Write-Information 'JSON file has more entries than YAML file' -InformationAction Continue
+        $hasChanges = $true
+    } else {
+        Write-Information 'YAML file has the same number of entries as JSON file' -InformationAction Continue
+        foreach ($key in $jsonData.Keys) {
+            if (-not $yamlData.ContainsKey($key)) {
+                Write-Debug "Found key in JSON missing from YAML: $key"
+                $yamlData[$key] = $jsonData[$key]
+                $hasChanges = $true
+            }
+        }
+    }
+
+    if ($hasChanges) {
+        Write-Information 'Found entries in JSON that need to be added to YAML' -InformationAction Continue
+        if ($PSCmdlet.ShouldProcess($yamlFile, 'Update YAML file with missing entries from JSON')) {
+            Write-Verbose 'Updating YAML file with missing entries from JSON'
+            $yamlData | ConvertTo-Yaml -OutFile $yamlFile -Force
+        }
+        if ($PSCmdlet.ShouldProcess($jsonFile, 'Update JSON file from YAML data')) {
+            Write-Verbose 'Updating JSON file from YAML data for consistency'
+            $yamlData | ConvertTo-Yaml `
+                -JsonCompatible `
+                -OutFile $jsonFile `
+                -Force
+        }
+        if (-not $WhatIfPreference) {
+            Write-Information 'Synchronized JSON to YAML.' -InformationAction Continue
+        }
+    } else {
+        Write-Information 'No changes needed for synchronization.' -InformationAction Continue
+    }
+} else {
+    Write-Information 'Both files are already synchronized.' -InformationAction Continue
+    Write-Debug "JSON and YAML timestamps are identical: $jsonLastModified"
+}
+
+Write-Verbose 'Redirects synchronization process completed'

--- a/scripts/Sync-Redirects.sh
+++ b/scripts/Sync-Redirects.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+#
+# DESCRIPTION:
+#   This script synchronizes the redirects between a JSON file and a YAML file.
+#   It checks which file is newer and updates the other file with any missing entries.
+#   If both files are the same, it does nothing.
+#   If the newer file is the YAML file, it converts it to JSON and writes it to the JSON file.
+#   If the newer file is the JSON file, it converts it to YAML and writes it to the YAML file.
+#
+# SYNOPSIS:
+#   Synchronize redirects between JSON and YAML files.
+#
+# USAGE:
+#   ./redirects-sync.sh [options]
+#
+# OPTIONS:
+#   -g, --git-root    The root directory of the Git repository. Defaults to the parent directory of the script.
+#   -j, --json-file   The path to the JSON file containing redirects.
+#   -y, --yaml-file   The path to the YAML file containing redirects.
+#   -v, --verbose     Enable verbose output.
+#   -d, --debug       Enable debug output.
+#   -h, --help        Display this help message and exit.
+#
+# DEPENDENCIES:
+#   - jq (for JSON processing)
+#   - yq (for YAML processing)
+#
+# EXAMPLE:
+#   ./redirects-sync.sh --json-file "/path/to/redirects.json" --yaml-file "/path/to/redirects.yaml"
+
+set -e
+
+# Function to display usage information
+show_help() {
+    echo "Usage: $(basename "$0") [options]"
+    echo "Synchronize redirects between JSON and YAML files."
+    echo ""
+    echo "Options:"
+    echo "  -g, --git-root DIR     The root directory of the Git repository"
+    echo "  -j, --json-file FILE   The path to the JSON file containing redirects"
+    echo "  -y, --yaml-file FILE   The path to the YAML file containing redirects"
+    echo "  -v, --verbose          Enable verbose output"
+    echo "  -d, --debug            Enable debug output"
+    echo "  -n, --dry-run          Show what would be done without making changes"
+    echo "  -h, --help             Display this help message and exit"
+}
+
+# Function for verbose output
+verbose() {
+    if [ "$VERBOSE" = true ]; then
+        echo "[INFO] $1"
+    fi
+}
+
+# Function for debug output
+debug() {
+    if [ "$DEBUG" = true ]; then
+        echo "[DEBUG] $1"
+    fi
+}
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to check dependencies
+check_dependencies() {
+    if ! command_exists jq; then
+        echo "Error: 'jq' is required but not installed. Please install it first."
+        exit 1
+    fi
+    
+    if ! command_exists yq; then
+        echo "Error: 'yq' is required but not installed. Please install it first."
+        exit 1
+    fi
+}
+
+# Initialize variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_ROOT="$(dirname "$SCRIPT_DIR")"
+JSON_FILE=""
+YAML_FILE=""
+VERBOSE=false
+DEBUG=false
+DRY_RUN=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -g|--git-root)
+            GIT_ROOT="$2"
+            shift 2
+            ;;
+        -j|--json-file)
+            JSON_FILE="$2"
+            shift 2
+            ;;
+        -y|--yaml-file)
+            YAML_FILE="$2"
+            shift 2
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -d|--debug)
+            DEBUG=true
+            VERBOSE=true
+            shift
+            ;;
+        -n|--dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Set default file paths if not provided
+if [ -z "$JSON_FILE" ]; then
+    JSON_FILE="$GIT_ROOT/redirects.json"
+fi
+
+if [ -z "$YAML_FILE" ]; then
+    YAML_FILE="$GIT_ROOT/redirects.yml"
+fi
+
+# Check if files exist
+if [ ! -f "$JSON_FILE" ]; then
+    echo "Error: JSON file '$JSON_FILE' does not exist."
+    exit 1
+fi
+
+if [ ! -f "$YAML_FILE" ]; then
+    echo "Error: YAML file '$YAML_FILE' does not exist."
+    exit 1
+fi
+
+# Log parameters
+debug "GIT_ROOT: $GIT_ROOT"
+debug "JSON_FILE: $JSON_FILE"
+debug "YAML_FILE: $YAML_FILE"
+debug "VERBOSE: $VERBOSE"
+debug "DEBUG: $DEBUG"
+debug "DRY_RUN: $DRY_RUN"
+
+# Check dependencies
+verbose "Checking dependencies"
+check_dependencies
+
+# Get file modification times
+verbose "Getting file modification times"
+JSON_MTIME=$(stat -c %Y "$JSON_FILE" 2>/dev/null || stat -f %m "$JSON_FILE")
+YAML_MTIME=$(stat -c %Y "$YAML_FILE" 2>/dev/null || stat -f %m "$JSON_FILE")
+debug "JSON last modified: $(date -r "$JSON_MTIME" 2>/dev/null || date -r "$JSON_FILE")"
+debug "YAML last modified: $(date -r "$YAML_MTIME" 2>/dev/null || date -r "$YAML_FILE")"
+
+# Count entries in files
+JSON_COUNT=$(jq 'length' "$JSON_FILE")
+YAML_COUNT=$(yq 'length' "$YAML_FILE")
+debug "JSON entries count: $JSON_COUNT"
+debug "YAML entries count: $YAML_COUNT"
+
+# Determine which file is newer and sync accordingly
+if [ "$JSON_MTIME" -gt "$YAML_MTIME" ]; then
+    verbose "JSON file is newer than YAML file"
+    
+    HAS_CHANGES=false
+    
+    if [ "$YAML_COUNT" -lt "$JSON_COUNT" ]; then
+        echo "JSON file has more entries than YAML file"
+        HAS_CHANGES=true
+    elif [ "$YAML_COUNT" -gt "$JSON_COUNT" ]; then
+        echo "YAML file has more entries than JSON file"
+        HAS_CHANGES=true
+    else
+        echo "JSON file has the same number of entries as YAML file"
+        # Compare keys in both files
+        # This is simplified and might need to be expanded based on your exact data structure
+        JSON_KEYS=$(jq -r 'keys[]' "$JSON_FILE" | sort)
+        YAML_KEYS=$(yq -r 'keys[]' "$YAML_FILE" | sort)
+        
+        if [ "$JSON_KEYS" != "$YAML_KEYS" ]; then
+            debug "Key differences found between JSON and YAML"
+            HAS_CHANGES=true
+        fi
+    fi
+    
+    if [ "$HAS_CHANGES" = true ]; then
+        echo "Found differences that need to be synchronized"
+        
+        if [ "$DRY_RUN" = false ]; then
+            verbose "Updating YAML file from JSON data"
+            cat "$JSON_FILE" | yq -y '.' > "$YAML_FILE"
+            echo "Synchronized JSON to YAML."
+        else
+            echo "[DRY RUN] Would synchronize JSON to YAML."
+        fi
+    else
+        echo "No changes needed for synchronization."
+    fi
+    
+elif [ "$YAML_MTIME" -gt "$JSON_MTIME" ]; then
+    verbose "YAML file is newer than JSON file"
+    
+    HAS_CHANGES=false
+    
+    if [ "$JSON_COUNT" -lt "$YAML_COUNT" ]; then
+        echo "YAML file has more entries than JSON file"
+        HAS_CHANGES=true
+    elif [ "$JSON_COUNT" -gt "$YAML_COUNT" ]; then
+        echo "JSON file has more entries than YAML file"
+        HAS_CHANGES=true
+    else
+        echo "YAML file has the same number of entries as JSON file"
+        # Compare keys in both files
+        JSON_KEYS=$(jq -r 'keys[]' "$JSON_FILE" | sort)
+        YAML_KEYS=$(yq -r 'keys[]' "$YAML_FILE" | sort)
+        
+        if [ "$JSON_KEYS" != "$YAML_KEYS" ]; then
+            debug "Key differences found between YAML and JSON"
+            HAS_CHANGES=true
+        fi
+    fi
+    
+    if [ "$HAS_CHANGES" = true ]; then
+        echo "Found differences that need to be synchronized"
+        
+        if [ "$DRY_RUN" = false ]; then
+            verbose "Updating JSON file from YAML data"
+            yq -j '.' "$YAML_FILE" > "$JSON_FILE"
+            echo "Synchronized YAML to JSON."
+        else
+            echo "[DRY RUN] Would synchronize YAML to JSON."
+        fi
+    else
+        echo "No changes needed for synchronization."
+    fi
+    
+else
+    echo "Both files are already synchronized."
+    debug "JSON and YAML timestamps are identical: $(date -r "$JSON_MTIME" 2>/dev/null || date -r "$JSON_FILE")"
+fi
+
+verbose "Redirects synchronization process completed"


### PR DESCRIPTION
- Updated GitHub Actions workflow to deploy from 'public/' instead of 'docs/'.
- Cleaned up the 'public/' directory before generating new redirect pages.
- Enhanced the HTML template for redirect pages with improved styling.
- Added category support in redirects JSON and YAML files for better organization.
- Created a new PowerShell script (Sync-Redirects.ps1) to synchronize redirects between JSON and YAML files.
- Developed a Bash script (Sync-Redirects.sh) for the same synchronization purpose with command-line options.
- Added external help XML for the PowerShell script for better documentation.
- Introduced a new markdown file (Sync-Redirects.md) to document the synchronization process.
- Updated .gitignore to exclude 'public/' and other unnecessary files.